### PR TITLE
Add initial tests and interpreter support

### DIFF
--- a/.github/workflows/ci-interpreter.yml
+++ b/.github/workflows/ci-interpreter.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Build interpreter
         run: cd interpreter && opam exec make
       - name: Run tests
-        run: cd interpreter && opam exec make JS=node ci
+        run: cd interpreter && opam exec make ci

--- a/.github/workflows/ci-interpreter.yml
+++ b/.github/workflows/ci-interpreter.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           ocaml-compiler: 4.14.x
       - name: Setup OCaml tools
-        run: opam install --yes ocamlfind.1.9.5 js_of_ocaml.4.0.0 js_of_ocaml-ppx.4.0.0
+        run: opam install --yes ocamlfind.1.9.5 js_of_ocaml.4.0.0 js_of_ocaml-ppx.4.0.0 stdint.0.7.2
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -506,6 +506,10 @@ let rec instr s =
     | 0x0fl -> table_grow (at var s)
     | 0x10l -> table_size (at var s)
     | 0x11l -> table_fill (at var s)
+    | 0x13l -> i64_add128
+    | 0x14l -> i64_sub128
+    | 0x15l -> i64_mul_wide_s
+    | 0x16l -> i64_mul_wide_u
 
     | n -> illegal2 s pos b n
     )

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -728,6 +728,11 @@ struct
     | VecReplace (V128 (F32x4 (V128Op.Replace i))) -> vecop 0x20l; byte i
     | VecReplace (V128 (F64x2 (V128Op.Replace i))) -> vecop 0x22l; byte i
 
+    | Binary128 Add128 -> op 0xfc; u32 0x13l
+    | Binary128 Sub128 -> op 0xfc; u32 0x14l
+    | BinaryWide MulS -> op 0xfc; u32 0x15l
+    | BinaryWide MulU -> op 0xfc; u32 0x16l
+
   let const c =
     list instr c.it; end_ ()
 

--- a/interpreter/dune
+++ b/interpreter/dune
@@ -3,6 +3,7 @@
 (library
   (public_name wasm)
   (modules :standard \ main wasm wast smallint)
+  (libraries stdint)
 )
 
 (executable

--- a/interpreter/dune-project
+++ b/interpreter/dune-project
@@ -18,5 +18,6 @@
   (depends
     (ocaml (>= 4.12))
     (menhir (>= 20220210))
+    (stdint (>= 0.7.2))
   )
 )

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -584,6 +584,14 @@ let rec step (c : config) : config =
         (try Vec (Eval_vec.eval_replaceop replaceop v r) :: vs', []
         with exn -> vs', [Trapping (numeric_error e.at exn) @@ e.at])
 
+      | Binary128 op, Num rhs_hi :: Num rhs_lo :: Num lhs_hi :: Num lhs_lo :: vs ->
+        let (lo, hi) = Eval_num.eval_binop128 op lhs_lo lhs_hi rhs_lo rhs_hi
+        in Num hi :: Num lo :: vs, []
+
+      | BinaryWide op, Num rhs :: Num lhs :: vs ->
+        let (lo, hi) = Eval_num.eval_binop_wide op lhs rhs
+        in Num hi :: Num lo :: vs, []
+
       | _ ->
         let s1 = string_of_values (List.rev vs) in
         let s2 = string_of_value_types (List.map type_of_value (List.rev vs)) in

--- a/interpreter/exec/eval_num.ml
+++ b/interpreter/exec/eval_num.ml
@@ -57,7 +57,27 @@ struct
 end
 
 module I32Op = IntOp (I32) (I32Num)
-module I64Op = IntOp (I64) (I64Num)
+module I64Op = struct
+  include IntOp (I64) (I64Num)
+
+  open I64Num
+
+  let binop128 op =
+    let f = match op with
+      | Ast.Add128 -> I64.add128
+      | Ast.Sub128 -> I64.sub128
+    in fun v1 v2 v3 v4 ->
+        let (a, b) = f (of_num 1 v1) (of_num 2 v2) (of_num 3 v3) (of_num 4 v4)
+        in (to_num a, to_num b)
+
+  let binop_wide op =
+    let f = match op with
+      | Ast.MulS -> I64.mul_wide_s
+      | Ast.MulU -> I64.mul_wide_u
+    in fun v1 v2 ->
+        let (a, b) = f (of_num 1 v1) (of_num 2 v2)
+        in (to_num a, to_num b)
+end
 
 
 (* Float operators *)
@@ -195,3 +215,5 @@ let eval_binop = op I32Op.binop I64Op.binop F32Op.binop F64Op.binop
 let eval_testop = op I32Op.testop I64Op.testop F32Op.testop F64Op.testop
 let eval_relop = op I32Op.relop I64Op.relop F32Op.relop F64Op.relop
 let eval_cvtop = op I32CvtOp.cvtop I64CvtOp.cvtop F32CvtOp.cvtop F64CvtOp.cvtop
+let eval_binop128 = I64Op.binop128
+let eval_binop_wide = I64Op.binop_wide

--- a/interpreter/exec/eval_num.mli
+++ b/interpreter/exec/eval_num.mli
@@ -5,3 +5,5 @@ val eval_binop : Ast.binop -> num -> num -> num
 val eval_testop : Ast.testop -> num -> bool
 val eval_relop : Ast.relop -> num -> num -> bool
 val eval_cvtop : Ast.cvtop -> num -> num
+val eval_binop128 : Ast.binop128 -> num -> num -> num -> num -> num * num
+val eval_binop_wide : Ast.binop_wide -> num -> num -> num * num

--- a/interpreter/exec/i64.ml
+++ b/interpreter/exec/i64.ml
@@ -9,3 +9,25 @@ include Ixx.Make
     let of_int64 i = i
     let to_int64 i = i
   end)
+
+open Stdint
+
+let to_i128 lo hi =
+  let lo = Int128.of_uint64 (Uint64.of_int64 lo) in
+  let hi = Int128.of_uint64 (Uint64.of_int64 hi) in
+  Int128.logor lo (Int128.shift_left hi 64)
+
+let split_i128 v =
+  let lo = Int64.of_int128 v in
+  let hi = Int64.of_int128 (Int128.shift_right v 64) in
+  (lo, hi)
+
+let add128 a b c d = split_i128 (Int128.add (to_i128 a b) (to_i128 c d))
+let sub128 a b c d = split_i128 (Int128.sub (to_i128 a b) (to_i128 c d))
+
+let mul_wide_s a b = split_i128 (Int128.mul (Int128.of_int64 a) (Int128.of_int64 b))
+let mul_wide_u a b =
+  let a = Uint64.of_int64 a in
+  let b = Uint64.of_int64 b in
+  let c = Uint128.mul (Uint128.of_uint64 a) (Uint128.of_uint64 b) in
+  split_i128 (Int128.of_uint128 c)

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -100,6 +100,8 @@ type unop = (I32Op.unop, I64Op.unop, F32Op.unop, F64Op.unop) Values.op
 type binop = (I32Op.binop, I64Op.binop, F32Op.binop, F64Op.binop) Values.op
 type relop = (I32Op.relop, I64Op.relop, F32Op.relop, F64Op.relop) Values.op
 type cvtop = (I32Op.cvtop, I64Op.cvtop, F32Op.cvtop, F64Op.cvtop) Values.op
+type binop128 = Add128 | Sub128
+type binop_wide = MulS | MulU
 
 type vec_testop = (V128Op.testop) Values.vecop
 type vec_relop = (V128Op.relop) Values.vecop
@@ -182,6 +184,8 @@ and instr' =
   | Compare of relop                  (* numeric comparison *)
   | Unary of unop                     (* unary numeric operator *)
   | Binary of binop                   (* binary numeric operator *)
+  | Binary128 of binop128             (* 128-bit operation taking 4 arguments *)
+  | BinaryWide of binop_wide          (* wide-arithmetic binop *)
   | Convert of cvtop                  (* conversion *)
   | VecConst of vec                   (* constant *)
   | VecTest of vec_testop             (* vector test *)

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -95,6 +95,7 @@ let rec instr (e : instr) =
     memories zero
   | MemoryInit x -> memories zero ++ datas (var x)
   | DataDrop x -> datas (var x)
+  | Binary128 _ | BinaryWide _ -> empty
 
 and block (es : instr list) =
   let free = list instr es in {free with labels = shift free.labels}

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -500,3 +500,8 @@ let f64x2_pmax = VecBinary (V128 (F64x2 V128Op.Pmax))
 let f64x2_promote_low_f32x4 = VecConvert (V128 (F64x2 V128Op.PromoteLowF32x4))
 let f64x2_convert_low_i32x4_s = VecConvert (V128 (F64x2 V128Op.ConvertSI32x4))
 let f64x2_convert_low_i32x4_u = VecConvert (V128 (F64x2 V128Op.ConvertUI32x4))
+
+let i64_add128 = Binary128 Add128
+let i64_sub128 = Binary128 Sub128
+let i64_mul_wide_s = BinaryWide MulS
+let i64_mul_wide_u = BinaryWide MulU

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -155,6 +155,14 @@ struct
     | TruncSatSF64 -> "trunc_sat_f64_s"
     | TruncSatUF64 -> "trunc_sat_f64_u"
     | ReinterpretFloat -> "reinterpret_f" ^ xx
+
+  let binop128 op = match op with
+    | Add128 -> "add128"
+    | Sub128 -> "sub128"
+
+  let binop_wide op = match op with
+    | MulS -> "mul_wide_s"
+    | MulU -> "mul_wide_u"
 end
 
 module FloatOp =
@@ -504,6 +512,8 @@ let rec instr e =
     | VecSplat op -> vec_splatop op, []
     | VecExtract op -> vec_extractop op, []
     | VecReplace op -> vec_replaceop op, []
+    | Binary128 op -> "i64." ^ (IntOp.binop128 op), []
+    | BinaryWide op -> "i64." ^ (IntOp.binop_wide op), []
   in Node (head, inner)
 
 let const head c =

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -84,7 +84,7 @@ let character =
     [^'"''\\''\x00'-'\x1f''\x7f'-'\xff']
   | utf8enc
   | '\\'escape
-  | '\\'hexdigit hexdigit 
+  | '\\'hexdigit hexdigit
   | "\\u{" hexnum '}'
 
 let nat = num | "0x" hexnum
@@ -654,6 +654,11 @@ rule token = parse
       | "i64x2.replace_lane" -> VEC_REPLACE i64x2_replace_lane
       | "f32x4.replace_lane" -> VEC_REPLACE f32x4_replace_lane
       | "f64x2.replace_lane" -> VEC_REPLACE f64x2_replace_lane
+
+      | "i64.add128" -> BINARY i64_add128
+      | "i64.sub128" -> BINARY i64_sub128
+      | "i64.mul_wide_s" -> BINARY i64_mul_wide_s
+      | "i64.mul_wide_u" -> BINARY i64_mul_wide_u
 
       | "type" -> TYPE
       | "func" -> FUNC

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -514,6 +514,12 @@ let rec check_instr (c : context) (e : instr) (s : infer_result_type) : op_type 
       "invalid lane index";
     [t; NumType t2] --> [t]
 
+  | Binary128 _ ->
+    [NumType I64Type; NumType I64Type; NumType I64Type; NumType I64Type] --> [NumType I64Type; NumType I64Type]
+
+  | BinaryWide _ ->
+    [NumType I64Type; NumType I64Type] --> [NumType I64Type; NumType I64Type]
+
 and check_seq (c : context) (s : infer_result_type) (es : instr list)
   : infer_result_type =
   match es with

--- a/interpreter/wasm.opam
+++ b/interpreter/wasm.opam
@@ -12,6 +12,7 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.12"}
   "menhir" {>= "20220210"}
+  "stdint" {>= "0.7.2"}
   "odoc" {with-doc}
 ]
 build: [

--- a/proposals/wide-arithmetic/Overview.md
+++ b/proposals/wide-arithmetic/Overview.md
@@ -281,8 +281,7 @@ plaininstr_l ::= ...
 
 Tests:
 
-* [ ] Core spec tests
-  * [example test in Wasmtime](https://github.com/bytecodealliance/wasmtime/blob/bc6b0fe4cb7c0d6f2fa436e185411db705e4a4ff/tests/misc_testsuite/wide-arithmetic.wast)
+* [x] [Core spec tests](https://github.com/WebAssembly/wide-arithmetic/pull/22)
 
 Engines:
 

--- a/proposals/wide-arithmetic/Overview.md
+++ b/proposals/wide-arithmetic/Overview.md
@@ -287,7 +287,7 @@ Tests:
 Engines:
 
 * [x] [Wasmtime](https://github.com/bytecodealliance/wasmtime/pull/9403)
-* [ ] Reference interpreter
+* [x] [Reference interpreter](https://github.com/WebAssembly/wide-arithmetic/pull/22)
 
 Toolchains:
 
@@ -296,12 +296,12 @@ Toolchains:
 Binary Decoders:
 
 * [x] [`wasmparser` in `wasm-tools`](https://github.com/bytecodealliance/wasm-tools/pull/1853)
-* [ ] Reference interpreter
+* [x] [Reference interpreter](https://github.com/WebAssembly/wide-arithmetic/pull/22)
 
 Validation:
 
 * [x] [`wasmparser` in `wasm-tools`](https://github.com/bytecodealliance/wasm-tools/pull/1853)
-* [ ] Reference interpreter
+* [x] [Reference interpreter](https://github.com/WebAssembly/wide-arithmetic/pull/22)
 
 Binary encoders:
 
@@ -310,7 +310,7 @@ Binary encoders:
 Text parsers:
 
 * [x] [`wast` in `wasm-tools`](https://github.com/bytecodealliance/wasm-tools/pull/1853)
-* [ ] Reference interpreter
+* [x] [Reference interpreter](https://github.com/WebAssembly/wide-arithmetic/pull/22)
 
 Fuzzing and test-case generation:
 

--- a/test/core/wide-arithmetic.wast
+++ b/test/core/wide-arithmetic.wast
@@ -1,0 +1,470 @@
+(module
+  (func (export "i64.add128") (param i64 i64 i64 i64) (result i64 i64)
+    local.get 0
+    local.get 1
+    local.get 2
+    local.get 3
+    i64.add128)
+  (func (export "i64.sub128") (param i64 i64 i64 i64) (result i64 i64)
+    local.get 0
+    local.get 1
+    local.get 2
+    local.get 3
+    i64.sub128)
+  (func (export "i64.mul_wide_s") (param i64 i64) (result i64 i64)
+    local.get 0
+    local.get 1
+    i64.mul_wide_s)
+  (func (export "i64.mul_wide_u") (param i64 i64) (result i64 i64)
+    local.get 0
+    local.get 1
+    i64.mul_wide_u)
+)
+
+;; simple addition
+(assert_return (invoke "i64.add128"
+                  (i64.const 0) (i64.const 0)
+                  (i64.const 0) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.add128"
+                  (i64.const 0) (i64.const 1)
+                  (i64.const 1) (i64.const 0))
+               (i64.const 1) (i64.const 1))
+(assert_return (invoke "i64.add128"
+                  (i64.const 1) (i64.const 0)
+                  (i64.const -1) (i64.const 0))
+               (i64.const 0) (i64.const 1))
+(assert_return (invoke "i64.add128"
+                  (i64.const 1) (i64.const 1)
+                  (i64.const -1) (i64.const -1))
+               (i64.const 0) (i64.const 1))
+
+;; simple subtraction
+(assert_return (invoke "i64.sub128"
+                  (i64.const 0) (i64.const 0)
+                  (i64.const 0) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.sub128"
+                  (i64.const 0) (i64.const 0)
+                  (i64.const 1) (i64.const 0))
+               (i64.const -1) (i64.const -1))
+(assert_return (invoke "i64.sub128"
+                  (i64.const 0) (i64.const 1)
+                  (i64.const 1) (i64.const 1))
+               (i64.const -1) (i64.const -1))
+(assert_return (invoke "i64.sub128"
+                  (i64.const 0) (i64.const 0)
+                  (i64.const 1) (i64.const 1))
+               (i64.const -1) (i64.const -2))
+
+;; simple mul_wide
+(assert_return (invoke "i64.mul_wide_s" (i64.const 0) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 0) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 1) (i64.const 1))
+               (i64.const 1) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 1) (i64.const 1))
+               (i64.const 1) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const -1) (i64.const -1))
+               (i64.const 1) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const -1) (i64.const 1))
+               (i64.const -1) (i64.const -1))
+(assert_return (invoke "i64.mul_wide_u" (i64.const -1) (i64.const 1))
+               (i64.const -1) (i64.const 0))
+
+;; 20 randomly generated test cases for i64.add128
+(assert_return (invoke "i64.add128"
+                   (i64.const -2418420703207364752) (i64.const -1)
+                   (i64.const -1) (i64.const -1))
+               (i64.const -2418420703207364753) (i64.const -1))
+(assert_return (invoke "i64.add128"
+                   (i64.const 0) (i64.const 0)
+                   (i64.const -4579433644172935106) (i64.const -1))
+               (i64.const -4579433644172935106) (i64.const -1))
+(assert_return (invoke "i64.add128"
+                   (i64.const 0) (i64.const 0)
+                   (i64.const 1) (i64.const -1))
+               (i64.const 1) (i64.const -1))
+(assert_return (invoke "i64.add128"
+                   (i64.const 1) (i64.const 0)
+                   (i64.const 1) (i64.const 0))
+               (i64.const 2) (i64.const 0))
+(assert_return (invoke "i64.add128"
+                   (i64.const -1) (i64.const -1)
+                   (i64.const -1) (i64.const -1))
+               (i64.const -2) (i64.const -1))
+(assert_return (invoke "i64.add128"
+                   (i64.const 0) (i64.const -1)
+                   (i64.const 1) (i64.const 0))
+               (i64.const 1) (i64.const -1))
+(assert_return (invoke "i64.add128"
+                   (i64.const 0) (i64.const 0)
+                   (i64.const 0) (i64.const -1))
+               (i64.const 0) (i64.const -1))
+(assert_return (invoke "i64.add128"
+                   (i64.const 1) (i64.const 0)
+                   (i64.const -1) (i64.const -1))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.add128"
+                   (i64.const 0) (i64.const 6184727276166606191)
+                   (i64.const 0) (i64.const 1))
+               (i64.const 0) (i64.const 6184727276166606192))
+(assert_return (invoke "i64.add128"
+                   (i64.const -8434911321912688222) (i64.const -1)
+                   (i64.const 1) (i64.const -1))
+               (i64.const -8434911321912688221) (i64.const -2))
+(assert_return (invoke "i64.add128"
+                   (i64.const 1) (i64.const -1)
+                   (i64.const 0) (i64.const -1))
+               (i64.const 1) (i64.const -2))
+(assert_return (invoke "i64.add128"
+                   (i64.const 1) (i64.const -5148941131328838092)
+                   (i64.const 0) (i64.const 0))
+               (i64.const 1) (i64.const -5148941131328838092))
+(assert_return (invoke "i64.add128"
+                   (i64.const 1) (i64.const 1)
+                   (i64.const 1) (i64.const 0))
+               (i64.const 2) (i64.const 1))
+(assert_return (invoke "i64.add128"
+                   (i64.const -1) (i64.const -1)
+                   (i64.const -3636740005180858631) (i64.const -1))
+               (i64.const -3636740005180858632) (i64.const -1))
+(assert_return (invoke "i64.add128"
+                   (i64.const -5529682780229988275) (i64.const -1)
+                   (i64.const 0) (i64.const 0))
+               (i64.const -5529682780229988275) (i64.const -1))
+(assert_return (invoke "i64.add128"
+                   (i64.const 1) (i64.const -5381447440966559717)
+                   (i64.const 1020031372481336745) (i64.const 1))
+               (i64.const 1020031372481336746) (i64.const -5381447440966559716))
+(assert_return (invoke "i64.add128"
+                   (i64.const 1) (i64.const 1)
+                   (i64.const 0) (i64.const 0))
+               (i64.const 1) (i64.const 1))
+(assert_return (invoke "i64.add128"
+                   (i64.const -9133888546939907356) (i64.const -1)
+                   (i64.const 1) (i64.const 1))
+               (i64.const -9133888546939907355) (i64.const 0))
+(assert_return (invoke "i64.add128"
+                   (i64.const -4612047512704241719) (i64.const -1)
+                   (i64.const 0) (i64.const -1))
+               (i64.const -4612047512704241719) (i64.const -2))
+(assert_return (invoke "i64.add128"
+                   (i64.const 414720966820876428) (i64.const -1)
+                   (i64.const 1) (i64.const 0))
+               (i64.const 414720966820876429) (i64.const -1))
+
+
+;; 20 randomly generated test cases for i64.sub128
+(assert_return (invoke "i64.sub128"
+                   (i64.const 0) (i64.const -2459085471354756766)
+                   (i64.const -9151153060221070927) (i64.const -1))
+               (i64.const 9151153060221070927) (i64.const -2459085471354756766))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 4566502638724063423) (i64.const -4282658540409485563)
+                   (i64.const -6884077310018979971) (i64.const -1))
+               (i64.const -6996164124966508222) (i64.const -4282658540409485563))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 1) (i64.const 3118380319444903041)
+                   (i64.const 0) (i64.const 3283115686417695443))
+               (i64.const 1) (i64.const -164735366972792402))
+(assert_return (invoke "i64.sub128"
+                   (i64.const -7208415241680161810) (i64.const -1)
+                   (i64.const 1) (i64.const 0))
+               (i64.const -7208415241680161811) (i64.const -1))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 0) (i64.const 3944850126731328706)
+                   (i64.const 1) (i64.const 1))
+               (i64.const -1) (i64.const 3944850126731328704))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 1) (i64.const -1)
+                   (i64.const -1) (i64.const -1))
+               (i64.const 2) (i64.const -1))
+(assert_return (invoke "i64.sub128"
+                   (i64.const -1) (i64.const -1)
+                   (i64.const 4855833073346115923) (i64.const -6826437637438999645))
+               (i64.const -4855833073346115924) (i64.const 6826437637438999644))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 1) (i64.const 0)
+                   (i64.const -1) (i64.const -1))
+               (i64.const 2) (i64.const 0))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 1) (i64.const 0)
+                   (i64.const 1) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.sub128"
+                   (i64.const -1) (i64.const -1)
+                   (i64.const 0) (i64.const 0))
+               (i64.const -1) (i64.const -1))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 1) (i64.const -1)
+                   (i64.const -6365475388498096428) (i64.const -1))
+               (i64.const 6365475388498096429) (i64.const -1))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 6804238617560992346) (i64.const -1)
+                   (i64.const 0) (i64.const -1))
+               (i64.const 6804238617560992346) (i64.const 0))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 0) (i64.const 1)
+                   (i64.const 1) (i64.const -7756145513466453619))
+               (i64.const -1) (i64.const 7756145513466453619))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 1) (i64.const -1)
+                   (i64.const 1) (i64.const 1))
+               (i64.const 0) (i64.const -2))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 0) (i64.const 1)
+                   (i64.const 1) (i64.const 0))
+               (i64.const -1) (i64.const 0))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 1) (i64.const 5602881641763648953)
+                   (i64.const -2110589244314239080) (i64.const -1))
+               (i64.const 2110589244314239081) (i64.const 5602881641763648953))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 0) (i64.const 1)
+                   (i64.const -1) (i64.const -1))
+               (i64.const 1) (i64.const 1))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 0) (i64.const -1)
+                   (i64.const 3553816990259121806) (i64.const -2105235417856431622))
+               (i64.const -3553816990259121806) (i64.const 2105235417856431620))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 1861102705894987245) (i64.const 1)
+                   (i64.const 3713781778534059871) (i64.const 1))
+               (i64.const -1852679072639072626) (i64.const -1))
+(assert_return (invoke "i64.sub128"
+                   (i64.const 0) (i64.const -1)
+                   (i64.const 1) (i64.const 1832524486821761762))
+               (i64.const -1) (i64.const -1832524486821761764))
+
+;; 20 randomly generated test cases for i64.mul_wide_s
+(assert_return (invoke "i64.mul_wide_s" (i64.const 1) (i64.const 1))
+               (i64.const 1) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 0) (i64.const 6287758211025156705))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const -6643537319803451357) (i64.const 1))
+               (i64.const -6643537319803451357) (i64.const -1))
+(assert_return (invoke "i64.mul_wide_s" (i64.const -2483565146858803428) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 1) (i64.const 1))
+               (i64.const 1) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const -3838951433439430085) (i64.const 3471602925362676030))
+               (i64.const 5186941893001237834) (i64.const -722475195264825124))
+(assert_return (invoke "i64.mul_wide_s" (i64.const -8262495286814853129) (i64.const 7883241869666573970))
+               (i64.const -8557189786755031842) (i64.const -3530988912334554469))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 4278371902407959701) (i64.const 1))
+               (i64.const 4278371902407959701) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const -8852706149487089182) (i64.const -1))
+               (i64.const 8852706149487089182) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 1) (i64.const -1))
+               (i64.const -1) (i64.const -1))
+(assert_return (invoke "i64.mul_wide_s" (i64.const -1) (i64.const -4329244561838653387))
+               (i64.const 4329244561838653387) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const -1) (i64.const -1))
+               (i64.const 1) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 697896157315764057) (i64.const 1))
+               (i64.const 697896157315764057) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 1) (i64.const 1))
+               (i64.const 1) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const -1) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 0) (i64.const -3769664482072947073))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 1) (i64.const 8414291037346403854))
+               (i64.const 8414291037346403854) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 1) (i64.const -1))
+               (i64.const -1) (i64.const -1))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 5014655679779318485) (i64.const -5080037812563681985))
+               (i64.const 2842857627777395563) (i64.const -1380983027057486843))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 0) (i64.const 1))
+               (i64.const 0) (i64.const 0))
+
+;; 20 randomly generated test cases for i64.mul_wide_u
+(assert_return (invoke "i64.mul_wide_u" (i64.const -4734436040338162711) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 1) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 3270597527173764279) (i64.const 6636648075495406358))
+               (i64.const -5430303818902260550) (i64.const 1176674035141685826))
+(assert_return (invoke "i64.mul_wide_u" (i64.const -7771814344630108151) (i64.const 1))
+               (i64.const -7771814344630108151) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 1) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 1) (i64.const -7864138787704962081))
+               (i64.const -7864138787704962081) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 1) (i64.const 518555141550256010))
+               (i64.const 518555141550256010) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 1) (i64.const -1))
+               (i64.const -1) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 1118900477321231571) (i64.const -1))
+               (i64.const -1118900477321231571) (i64.const 1118900477321231570))
+(assert_return (invoke "i64.mul_wide_u" (i64.const -1) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const -5586890671027490027) (i64.const 1))
+               (i64.const -5586890671027490027) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 0) (i64.const 3603850799751152505))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const -1) (i64.const -1))
+               (i64.const 1) (i64.const 18446744073709551614))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 0) (i64.const 1))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const -7344082851774441644) (i64.const 3896439839137544024))
+               (i64.const 5738542512914895072) (i64.const 2345175459296971666))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 0) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 616395976148874061) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 2810729703362889816) (i64.const -1))
+               (i64.const -2810729703362889816) (i64.const 2810729703362889815))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 1) (i64.const -1))
+               (i64.const -1) (i64.const 0))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 1) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+
+;; assert overlong encodings for each instruction's binary encoding are accepted
+(module binary
+  "\00asm" "\01\00\00\00"
+
+  "\01\11"                  ;; type section, 17 bytes
+  "\02"                     ;; 2 count
+  "\60"                     ;; type0 = function
+  "\04\7e\7e\7e\7e"         ;;  4 params - all i64
+  "\02\7e\7e"               ;;  2 results - both i64
+  "\60"                     ;; type1 = function
+  "\02\7e\7e"               ;;  2 params - both i64
+  "\02\7e\7e"               ;;  2 results - both i64
+
+  "\03\05"                  ;; function section, 5 byte
+  "\04"                     ;; 4 count
+  "\00\00\01\01"            ;; types of each function (0, 0, 1, 1)
+
+  "\07\3d"                  ;; export section 0x3d bytes
+  "\04"                     ;; 4 count
+  "\0ai64.add128\00\00"     ;; "i64.add128" which is function 0
+  "\0ai64.sub128\00\01"     ;; "i64.add128" which is function 1
+  "\0ei64.mul_wide_s\00\02" ;; "i64.mul_wide_s" which is function 2
+  "\0ei64.mul_wide_u\00\03" ;; "i64.mul_wide_s" which is function 3
+
+  "\0a\37"                  ;; code section + byte length
+  "\04"                     ;; 4 count
+
+  "\0e"                     ;; byte length
+  "\00"                     ;; no locals
+  "\20\00"                  ;; local.get 0
+  "\20\01"                  ;; local.get 1
+  "\20\02"                  ;; local.get 2
+  "\20\03"                  ;; local.get 3
+  "\fc\93\80\00"            ;; i64.add128 (overlong)
+  "\0b"                     ;; end
+
+  "\0d"                     ;; byte length
+  "\00"                     ;; no locals
+  "\20\00"                  ;; local.get 0
+  "\20\01"                  ;; local.get 1
+  "\20\02"                  ;; local.get 2
+  "\20\03"                  ;; local.get 3
+  "\fc\94\00"               ;; i64.sub128 (overlong)
+  "\0b"                     ;; end
+
+  "\0c"                     ;; byte length
+  "\00"                     ;; no locals
+  "\20\00"                  ;; local.get 0
+  "\20\01"                  ;; local.get 1
+  "\fc\95\80\80\80\00"      ;; i64.mul_wide_s (overlong)
+  "\0b"                     ;; end
+
+  "\0b"                     ;; byte length
+  "\00"                     ;; no locals
+  "\20\00"                  ;; local.get 0
+  "\20\01"                  ;; local.get 1
+  "\fc\96\80\80\00"         ;; i64.mul_wide_u (overlong)
+  "\0b"                     ;; end
+)
+
+(assert_return (invoke "i64.add128"
+                  (i64.const 1) (i64.const 2)
+                  (i64.const 3) (i64.const 4))
+               (i64.const 4) (i64.const 6))
+(assert_return (invoke "i64.sub128"
+                  (i64.const 2) (i64.const 5)
+                  (i64.const 1) (i64.const 2))
+               (i64.const 1) (i64.const 3))
+(assert_return (invoke "i64.mul_wide_s" (i64.const 1) (i64.const -2))
+               (i64.const -2) (i64.const -1))
+(assert_return (invoke "i64.mul_wide_u" (i64.const 3) (i64.const 2))
+               (i64.const 6) (i64.const 0))
+
+;; some invalid types for these instructions
+
+(assert_invalid
+  (module
+    (func (param i64 i64 i64 i64) (result i64)
+      local.get 0
+      local.get 1
+      local.get 2
+      local.get 3
+      i64.add128)
+  )
+  "type mismatch")
+(assert_invalid
+  (module
+    (func (param i64 i64 i64) (result i64 i64)
+      local.get 0
+      local.get 1
+      local.get 2
+      i64.add128)
+  )
+  "type mismatch")
+
+(assert_invalid
+  (module
+    (func (param i64 i64 i64 i64) (result i64)
+      local.get 0
+      local.get 1
+      local.get 2
+      local.get 3
+      i64.sub128)
+  )
+  "type mismatch")
+(assert_invalid
+  (module
+    (func (param i64 i64 i64) (result i64 i64)
+      local.get 0
+      local.get 1
+      local.get 2
+      i64.sub128)
+  )
+  "type mismatch")
+
+(assert_invalid
+  (module
+    (func (param i64 i64) (result i64)
+      local.get 0
+      local.get 1
+      i64.mul_wide_s)
+  )
+  "type mismatch")
+(assert_invalid
+  (module
+    (func (param i64) (result i64 i64)
+      local.get 0
+      i64.mul_wide_s)
+  )
+  "type mismatch")
+
+(assert_invalid
+  (module
+    (func (param i64 i64) (result i64)
+      local.get 0
+      local.get 1
+      i64.mul_wide_u)
+  )
+  "type mismatch")
+(assert_invalid
+  (module
+    (func (param i64) (result i64 i64)
+      local.get 0
+      i64.mul_wide_u)
+  )
+  "type mismatch")


### PR DESCRIPTION
This commit updates the reference interpreter with the new instructions proposed here along with an initial `*.wast` test imported from Wasmtime's own test suite plus a few extra tests.