### PR TITLE
Add chasm to supported engine list

### DIFF
--- a/proposals/wide-arithmetic/Overview.md
+++ b/proposals/wide-arithmetic/Overview.md
@@ -288,6 +288,7 @@ Engines:
 * [x] [Wasmtime](https://github.com/bytecodealliance/wasmtime/pull/9403)
 * [x] [Reference interpreter](https://github.com/WebAssembly/wide-arithmetic/pull/22)
 * [x] [Wasmi](https://github.com/wasmi-labs/wasmi/pull/1383)
+* [x] [Chasm](https://github.com/CharlieTap/chasm/pull/110)
 
 Toolchains:
 


### PR DESCRIPTION
This was a pretty simple proposal given chasm is an interpreter and we don't have the complications of lowering the instructions to something efficient. Now we just cross our fingers the opcodes/impl doesn't change between now and being standardised 😬 