### PR TITLE
Add JavaScriptCore to implementations

### DIFF
--- a/proposals/wide-arithmetic/Overview.md
+++ b/proposals/wide-arithmetic/Overview.md
@@ -289,6 +289,7 @@ Engines:
 * [x] [Reference interpreter](https://github.com/WebAssembly/wide-arithmetic/pull/22)
 * [x] [Wasmi](https://github.com/wasmi-labs/wasmi/pull/1383)
 * [x] [Chasm](https://github.com/CharlieTap/chasm/pull/110)
+* [x] [JavaScriptCore](https://commits.webkit.org/311366@main)
 
 Toolchains:
 


### PR DESCRIPTION
JSC added support in https://commits.webkit.org/311366@main for wide arithmetic behind a flag (useWasmWideArithmetic).